### PR TITLE
Fixes problem of setWhere causing features to not load outside of cur…

### DIFF
--- a/src/ClusteredFeatureLayer.js
+++ b/src/ClusteredFeatureLayer.js
@@ -54,30 +54,30 @@ export var FeatureLayer = FeatureManager.extend({
       var layer = this._layers[geojson.id];
 
       if (!layer) {
-        var newLayer = L.GeoJSON.geometryToLayer(geojson, this.options);
-        newLayer.feature = L.GeoJSON.asFeature(geojson);
-        newLayer.defaultOptions = newLayer.options;
-        newLayer._leaflet_id = this._key + '_' + geojson.id;
+        layer = L.GeoJSON.geometryToLayer(geojson, this.options);
+        layer.feature = L.GeoJSON.asFeature(geojson);
+        layer.defaultOptions = layer.options;
+        layer._leaflet_id = this._key + '_' + geojson.id;
 
-        this.resetStyle(newLayer.feature.id);
+        this.resetStyle(layer.feature.id);
 
         // cache the layer
-        this._layers[newLayer.feature.id] = newLayer;
+        this._layers[layer.feature.id] = layer;
 
-        this._leafletIds[newLayer._leaflet_id] = geojson.id;
+        this._leafletIds[layer._leaflet_id] = geojson.id;
 
         if (this.options.onEachFeature) {
-          this.options.onEachFeature(newLayer.feature, newLayer);
+          this.options.onEachFeature(layer.feature, layer);
         }
 
         this.fire('createfeature', {
-          feature: newLayer.feature
+          feature: layer.feature
         });
+      }
 
-        // add the layer if it is within the time bounds or our layer is not time enabled
-        if (!this.options.timeField || (this.options.timeField && this._featureWithinTimeRange(geojson))) {
-          markers.push(newLayer);
-        }
+      // add the layer if it is within the time bounds or our layer is not time enabled
+      if (!this.options.timeField || (this.options.timeField && this._featureWithinTimeRange(geojson))) {
+        markers.push(layer);
       }
     }
 


### PR DESCRIPTION
…rent virtual grid.

esri-leaflet - v2.0.7
Leaflet 1.0.2

To reproduce:

- Have a map with a cluster layer
- Start at zoom say 13.
![cluster1](https://cloud.githubusercontent.com/assets/4510944/22841174/f744fe00-efa6-11e6-995c-ddfc7c68367f.PNG)

-Zoom in to say 16
![cluster2](https://cloud.githubusercontent.com/assets/4510944/22841201/0877decc-efa7-11e6-9161-19517261a745.PNG)

- Call setWhere to filter the layer (in this case, Price > 300K)
![cluster3](https://cloud.githubusercontent.com/assets/4510944/22841217/1679666c-efa7-11e6-854e-ba06fc0ca5d1.PNG)

- Pan outside of the current map bounds, features that should be there based on the setWhere clause are not.
![cluster4](https://cloud.githubusercontent.com/assets/4510944/22841228/246b415a-efa7-11e6-8493-5cc14790c85e.PNG)

The problem, from what I can tell is that when setWhere is called it stores the current snapshot, sends out the new requests for the new snapshot based on the 'where' clause and then removes the layers in the old snapshot.

The `removeLayers` in ClusteredFeatureLayer.js that gets called removes the layers from `this.cluster`.  The problem is that subsequent calls to `createLayers` in ClusteredFeatureLayer.js finds the layers in `this._layers` which means it does not get put into the markers array via `markers.push(newLayer);` and never makes it back into the cluster via the call to `this.cluster.addLayers(markers);`.

This change appears to fix the problem, maybe not the best fix.  The down side is layers will get re-added to the cluster but it ignores layers if it already has them.

I admit I did not fully run the tests, I am having problems with starting PhantomJS.  I am still quite new to the whole Node thing.