### PR TITLE
port createNewLayer from L.esri.featureLayer for renderer plugin

### DIFF
--- a/src/ClusterFeatureLayer.js
+++ b/src/ClusterFeatureLayer.js
@@ -1,4 +1,4 @@
-import L from 'leaflet';
+import { setOptions, GeoJSON, markerClusterGroup } from 'leaflet';
 import { FeatureManager } from 'esri-leaflet';
 export { version as VERSION } from '../package.json';
 
@@ -16,12 +16,12 @@ export var FeatureLayer = FeatureManager.extend({
   initialize: function (options) {
     FeatureManager.prototype.initialize.call(this, options);
 
-    options = L.setOptions(this, options);
+    options = setOptions(this, options);
 
     this._layers = {};
     this._leafletIds = {};
 
-    this.cluster = L.markerClusterGroup(options);
+    this.cluster = markerClusterGroup(options);
     this._key = 'c' + (Math.random() * 1e9).toString(36).replace('.', '_');
 
     this.cluster.addEventParent(this);
@@ -45,6 +45,15 @@ export var FeatureLayer = FeatureManager.extend({
    * Feature Management Methods
    */
 
+  createNewLayer: function (geojson) {
+    var layer = GeoJSON.geometryToLayer(geojson, this.options);
+    // trap for GeoJSON without geometry
+    if (layer) {
+      layer.defaultOptions = layer.options;
+    }
+    return layer;
+  },
+
   createLayers: function (features) {
     var markers = [];
 
@@ -53,8 +62,8 @@ export var FeatureLayer = FeatureManager.extend({
       var layer = this._layers[geojson.id];
 
       if (!layer) {
-        layer = L.GeoJSON.geometryToLayer(geojson, this.options);
-        layer.feature = L.GeoJSON.asFeature(geojson);
+        layer = this.createNewLayer(geojson);
+        layer.feature = GeoJSON.asFeature(geojson);
         layer.defaultOptions = layer.options;
         layer._leaflet_id = this._key + '_' + geojson.id;
 


### PR DESCRIPTION
just a small tweak to make Cluster.featureLayer look more like [esri.featureLayer](https://github.com/Esri/esri-leaflet/blob/542022a2f216b7ad43471876a693a0257e92582d/src/Layers/FeatureLayer/FeatureLayer.js) for the sake of https://github.com/Esri/esri-leaflet-renderers/pull/158

to be honest, i have no clue how this was working in [`esri-leaflet-renderers@1.0.1`](https://github.com/Esri/esri-leaflet-renderers/blob/v1.0.1/src/FeatureLayerHook.js#L5)