### PR TITLE
fix: use default export instead of named export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -374,9 +374,9 @@
       "dev": true
     },
     "@terraformer/arcgis": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@terraformer/arcgis/-/arcgis-2.0.7.tgz",
-      "integrity": "sha512-7jIQcnd8RnKsDt1IxmEjq9t7l5fnf0e5c+c1+1GjG4NR+TY0XkJcWtrBv0DWd65uAlDiQYMlEG8ls5dz1GQiuA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@terraformer/arcgis/-/arcgis-2.1.0.tgz",
+      "integrity": "sha512-eKTvNXze2Fo7vAEjvJFIGn5QdU0OP4aD9DuT/uTBLRM1QS+ju7KtPITbVW+xgCviHLnOVeFQ1UsIs9kjkakD4g==",
       "requires": {
         "@terraformer/common": "^2.0.7"
       }
@@ -2240,9 +2240,9 @@
       }
     },
     "esri-leaflet": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/esri-leaflet/-/esri-leaflet-2.4.1.tgz",
-      "integrity": "sha512-0ukZIhA9dVx8yYe/ahp2yZm7GmUYTxPktXXHBVPBZoe9I00fkhLsEk2dIt1xa7XsCk/gH+Breb9L5lNALC+Niw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/esri-leaflet/-/esri-leaflet-3.0.2.tgz",
+      "integrity": "sha512-Dr5Ie52yH+gojfnGXdzHGkrgn9U3kp9QKB7xqXZX/mPIE9gKyqC5Er8jRifJx+DTgeM67F+P7F09ZJsIvWbheQ==",
       "requires": {
         "@terraformer/arcgis": "^2.0.7",
         "tiny-binary-search": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "John Gravois <jgravois@esri.com> (http://johngravois.com)"
   ],
   "dependencies": {
-    "esri-leaflet": "^2.0.0",
+    "esri-leaflet": "^3.0.2",
     "leaflet": "^1.0.0",
     "leaflet.markercluster": "^1.0.0"
   },

--- a/src/ClusterFeatureLayer.js
+++ b/src/ClusterFeatureLayer.js
@@ -174,7 +174,7 @@ export var FeatureLayer = FeatureManager.extend({
   }
 });
 
-export function featureLayer(options) {
+export function featureLayer (options) {
   return new FeatureLayer(options);
 }
 

--- a/src/ClusterFeatureLayer.js
+++ b/src/ClusterFeatureLayer.js
@@ -1,6 +1,8 @@
 import { setOptions, GeoJSON, markerClusterGroup } from 'leaflet';
 import { FeatureManager } from 'esri-leaflet';
-export { version as VERSION } from '../package.json';
+import packageInfo from '../package.json';
+var version = packageInfo.version;
+export { version as VERSION };
 
 export var FeatureLayer = FeatureManager.extend({
 
@@ -172,7 +174,7 @@ export var FeatureLayer = FeatureManager.extend({
   }
 });
 
-export function featureLayer (options) {
+export function featureLayer(options) {
   return new FeatureLayer(options);
 }
 


### PR DESCRIPTION
With this you can use Webpack 5 without warnings (or even errors in case of angular 12).
All credits to @destus90, who fixed the same thing in the esri-leaflet package (https://github.com/Esri/esri-leaflet/pull/1273)

https://webpack.js.org/migrate/5/#cleanup-the-code 

> Using named exports from JSON modules: this is not supported by the new specification and you will get a warning. Instead of import { version } from './package.json' use import package from './package.json'; const { version } = package;