### PR TITLE
fix: Use default export from package instead of named export version.

### DIFF
--- a/src/ClusterFeatureLayer.js
+++ b/src/ClusterFeatureLayer.js
@@ -1,6 +1,7 @@
 import { setOptions, GeoJSON, markerClusterGroup } from 'leaflet';
 import { FeatureManager } from 'esri-leaflet';
-export { version as VERSION } from '../package.json';
+import packageInfo from '../package.json';
+export var VERSION = packageInfo.version;
 
 export var FeatureLayer = FeatureManager.extend({
 


### PR DESCRIPTION
Using named exports from JSON modules is not supported by the new specification in Webpack v5